### PR TITLE
Package immich-cli in Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker build
 
 on:
   workflow_dispatch:
-    push:
+  push:
     branches: [main]
   release:
     types: [created]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,37 @@
+name: Docker build
+
+on:
+  workflow_dispatch:
+    push:
+    branches: [main]
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/immich-cli
+      
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16-alpine3.14 as core
+
+WORKDIR /usr/src/app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm install -g
+
+WORKDIR /import
+ENTRYPOINT [ "immich" ]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ immich upload --email testuser@email.com --password password --server http://192
 
 ### Run via Docker
 
-Be aware that as this runs inside a container, it mounts your current directory as a volume.
+Be aware that as this runs inside a container, it mounts your current directory as a volume and for the -d flag you need to use the path inside the container.
 ```
 docker run -it --rm -v $(pwd):/import ghcr.io/alextran1502/immich-cli:v0.5.0 upload --email testuser@email.com --password password --server http://192.168.1.216:2283/api -d /import
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ immich upload --email testuser@email.com --password password --server http://192
 
 ---
 
+### Run via Docker
+
+Be aware that as this runs inside a container, it mounts your current directory as a volume.
+```
+docker run -it --rm -v $(pwd):/import ghcr.io/alextran1502/immich-cli:v0.5.0 upload --email testuser@email.com --password password --server http://192.168.1.216:2283/api -d /import
+```
+
+Optionally, you can create an alias:
+```
+alias immich="docker run -it --rm -v $(pwd):/import ghcr.io/alextran1502/immich-cli:v0.5.0"  
+immich upload --email testuser@email.com --password password --server http://192.168.1.216:2283/api -d /import
+```
+
 ### Install from source
 
 1 - Clone Repository

--- a/bin/index.js
+++ b/bin/index.js
@@ -57,7 +57,7 @@ program.parse(process.argv);
 
 async function upload({ email, password, server, directory }) {
   const endpoint = server;
-  const deviceId = (await si.uuid()).os;
+  const deviceId = (await si.uuid()).os || "CLI";
   const osInfo = (await si.osInfo()).distro;
   const localAssets = [];
   const newAssets = [];


### PR DESCRIPTION
This change allows for easily using the tool in environments where `node` is not available, or for long running jobs in settings like Kubernetes.